### PR TITLE
会員登録画面 実装

### DIFF
--- a/work28/src/register-done/index.html
+++ b/work28/src/register-done/index.html
@@ -12,6 +12,6 @@
     <script defer type="module" src="./js/index.js"></script>
   </head>
   <body>
-    <h1>ページ登録完了</h1>
+    <h1>会員登録完了</h1>
   </body>
 </html>

--- a/work28/src/register/index.html
+++ b/work28/src/register/index.html
@@ -22,7 +22,7 @@
           <div class="userMail">
             <label for="mail">メールアドレス</label>
             <div class="columnBox">
-              <input type="text" name="mail" id="mail" required />
+              <input type="mail" name="mail" id="mail" required />
               <p class="invalidError mail">
                 ※メールアドレスの形式になっていません。
               </p>
@@ -31,7 +31,7 @@
           <div class="userPassword">
             <label for="password">パスワード</label>
             <div class="columnBox">
-              <input type="text" name="password" id="password" required />
+              <input type="password" name="password" id="password" required />
               <p class="invalidError password">
                 ※8文字以上の大小の英数字を交ぜたものにしてください。
               </p>

--- a/work28/src/register/index.html
+++ b/work28/src/register/index.html
@@ -18,52 +18,41 @@
       </div>
 
       <div class="form_area">
-        <form action="./register-done.html">
-          <div class="form_area-input">
-            <div class="userName">
-              <label for="name">ユーザー名</label>
-              <div class="columnBox">
-                <input type="text" name="name" id="name" required />
-                <p class="invalidError name">
-                  ※ユーザー名は15文字以下にしてください。
-                </p>
-              </div>
-            </div>
-            <div class="userMail">
-              <label for="mail">メールアドレス</label>
-              <div class="columnBox">
-                <input type="text" name="mail" id="mail" required />
-                <p class="invalidError mail">
-                  ※メールアドレスの形式になっていません。
-                </p>
-              </div>
-            </div>
-            <div class="userPassword">
-              <label for="password">パスワード</label>
-              <div class="columnBox">
-                <input type="text" name="password" id="password" required />
-                <p class="invalidError password">
-                  ※8文字以上の大小の英数字を交ぜたものにしてください。
-                </p>
-              </div>
+        <div class="form_area-input">
+          <div class="userMail">
+            <label for="mail">メールアドレス</label>
+            <div class="columnBox">
+              <input type="text" name="mail" id="mail" required />
+              <p class="invalidError mail">
+                ※メールアドレスの形式になっていません。
+              </p>
             </div>
           </div>
-          <div class="register">
-            <input
-              type="checkbox"
-              name="register"
-              id="register"
-              disabled
-              aria-label="利用規約に同意するチェックボックス（自動的に選択されます）"
-            />
-            <span class="registerText">利用規約</span>に同意する
+          <div class="userPassword">
+            <label for="password">パスワード</label>
+            <div class="columnBox">
+              <input type="text" name="password" id="password" required />
+              <p class="invalidError password">
+                ※8文字以上の大小の英数字を交ぜたものにしてください。
+              </p>
+            </div>
           </div>
-          <div class="submit">
-            <button class="submitBtn" id="js-submitBtn" type="submit" disabled>
-              送信
-            </button>
-          </div>
-        </form>
+        </div>
+        <div class="register">
+          <input
+            type="checkbox"
+            name="register"
+            id="register"
+            disabled
+            aria-label="利用規約に同意するチェックボックス（自動的に選択されます）"
+          />
+          <span class="registerText">利用規約</span>に同意する
+        </div>
+        <div class="submit">
+          <button class="submitBtn" id="js-submitBtn" type="submit" disabled>
+            送信
+          </button>
+        </div>
       </div>
     </div>
 

--- a/work28/src/register/js/RegisterMockServer.ts
+++ b/work28/src/register/js/RegisterMockServer.ts
@@ -1,7 +1,7 @@
 export const userRegister = (user: { mail: string; password: string }) => {
   if (isUserRegisterNeededServer(user.mail)) {
-    localStorage.setItem("registerUserMail", user.mail);
-    localStorage.setItem("registerUserPassword", user.password);
+    const registerUserJson = JSON.stringify(user);
+    localStorage.setItem("registerUser", registerUserJson);
 
     return true;
   }
@@ -9,9 +9,15 @@ export const userRegister = (user: { mail: string; password: string }) => {
 };
 
 const isUserRegisterNeededServer = (userMail: string) => {
-  const registerUserInfoServer = localStorage.getItem("registerUserMail");
+  const registerUserInfoServer = localStorage.getItem("registerUser");
 
-  if (registerUserInfoServer === userMail) {
+  if (!registerUserInfoServer) {
+    return true;
+  }
+
+  const registerUserJson = JSON.parse(registerUserInfoServer);
+
+  if (registerUserJson.mail === userMail) {
     alert("すでに登録されているメールアドレスです。");
     return false;
   }

--- a/work28/src/register/js/RegisterMockServer.ts
+++ b/work28/src/register/js/RegisterMockServer.ts
@@ -1,0 +1,20 @@
+export const userRegister = (user: { mail: string; password: string }) => {
+  if (isUserRegisterNeededServer(user.mail)) {
+    localStorage.setItem("registerUserMail", user.mail);
+    localStorage.setItem("registerUserPassword", user.password);
+
+    return true;
+  }
+  return false;
+};
+
+const isUserRegisterNeededServer = (userMail: string) => {
+  const registerUserInfoServer = localStorage.getItem("registerUserMail");
+
+  if (registerUserInfoServer === userMail) {
+    alert("すでに登録されているメールアドレスです。");
+    return false;
+  }
+
+  return true;
+};

--- a/work28/src/register/js/index.js
+++ b/work28/src/register/js/index.js
@@ -1,7 +1,4 @@
-const registerTextElem = document.querySelector('.registerText');
-const closeBtn = document.querySelector('.closeBtn');
-const modalContentsElem = document.querySelector('.modal_contents');
-const registerCheckBox = document.getElementById('register');
+import { userRegister } from "./RegisterMockServer";
 
 const registerTextElem = document.querySelector(".registerText");
 const closeBtn = document.querySelector(".closeBtn");
@@ -97,3 +94,8 @@ const toggleSubmit = () => {
   registerSubmitBtn.disabled = !allValid;
 };
 
+registerSubmitBtn.addEventListener("click", () => {
+  if (!userRegister(inputValueState)) return;
+
+  window.location.href = "../register-done/index.html";
+});

--- a/work28/src/register/js/index.js
+++ b/work28/src/register/js/index.js
@@ -3,99 +3,97 @@ const closeBtn = document.querySelector('.closeBtn');
 const modalContentsElem = document.querySelector('.modal_contents');
 const registerCheckBox = document.getElementById('register');
 
+const registerTextElem = document.querySelector(".registerText");
+const closeBtn = document.querySelector(".closeBtn");
+const modalContentsElem = document.querySelector(".modal_contents");
+const registerCheckBox = document.getElementById("register");
+const registerSubmitBtn = document.getElementById("js-submitBtn");
+
 const validState = {
-    name: false,
-    mail: false,
-    password: false,
-    register: false,
+  mail: false,
+  password: false,
+  register: false,
 };
 
-registerTextElem.addEventListener('click', () => {
-    const modalElem = document.getElementById('js-modal');
-    modalElem.classList.remove('close');
-    modalElem.classList.add('open');
+const inputValueState = {
+  mail: "",
+  password: "",
+};
+
+registerTextElem.addEventListener("click", () => {
+  const modalElem = document.getElementById("js-modal");
+  modalElem.classList.remove("close");
+  modalElem.classList.add("open");
 });
 
-closeBtn.addEventListener('click', () => {
-    const modalElem = document.getElementById('js-modal');
-    modalElem.classList.remove('open');
-    modalElem.classList.add('close');
+closeBtn.addEventListener("click", () => {
+  const modalElem = document.getElementById("js-modal");
+  modalElem.classList.remove("open");
+  modalElem.classList.add("close");
 });
 
-modalContentsElem.addEventListener('scroll', () => {
-    if (registerCheckBox.checked) return;
-    const registerListElem = document.querySelectorAll('.modal li');
+modalContentsElem.addEventListener("scroll", () => {
+  if (registerCheckBox.checked) return;
+  const registerListElem = document.querySelectorAll(".modal li");
 
-    if (registerListElem.length > 0) {
-        const lastElem = registerListElem[registerListElem.length - 1];
-        const modalHeight = modalContentsElem.clientHeight;
-        const lastElemPos =
-            lastElem.getBoundingClientRect().top -
-            modalContentsElem.getBoundingClientRect().top;
+  if (registerListElem.length > 0) {
+    const lastElem = registerListElem[registerListElem.length - 1];
+    const modalHeight = modalContentsElem.clientHeight;
+    const lastElemPos =
+      lastElem.getBoundingClientRect().top -
+      modalContentsElem.getBoundingClientRect().top;
 
-        if (lastElemPos < modalHeight) {
-            registerCheckBox.checked = true;
-            registerCheckBox.disabled = false;
-            validState.register = true;
+    if (lastElemPos < modalHeight) {
+      registerCheckBox.checked = true;
+      registerCheckBox.disabled = false;
+      validState.register = true;
 
-            toggleSubmit();
-        }
+      toggleSubmit();
     }
-});
-
-const userNameInputElem = document.querySelector('input[name="name"]');
-userNameInputElem.addEventListener('keyup', () => {
-    const invalidElem = document.querySelector('.invalidError.name');
-    if (userNameInputElem.value.length > 15) {
-        invalidElem.style.display = 'block';
-        validState.name = false;
-    } else {
-        invalidElem.style.display = 'none';
-        validState.name = true;
-    }
-
-    toggleSubmit();
+  }
 });
 
 const mailInputElem = document.querySelector('input[name="mail"]');
-mailInputElem.addEventListener('keyup', () => {
-    const mailValue = mailInputElem.value.trim();
-    const invalidElem = document.querySelector('.invalidError.mail');
-    const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+mailInputElem.addEventListener("keyup", () => {
+  const mailValue = mailInputElem.value.trim();
+  const invalidElem = document.querySelector(".invalidError.mail");
+  const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
-    if (!emailRegex.test(mailValue)) {
-        invalidElem.style.display = 'block';
-        validState.mail = false;
-    } else {
-        invalidElem.style.display = 'none';
-        validState.mail = true;
-    }
+  if (!emailRegex.test(mailValue)) {
+    invalidElem.style.display = "block";
+    validState.mail = false;
+  } else {
+    invalidElem.style.display = "none";
+    validState.mail = true;
+    inputValueState.mail = mailValue;
+  }
 
-    toggleSubmit();
+  toggleSubmit();
 });
 
 const passwordInputElem = document.querySelector('input[name="password"]');
-passwordInputElem.addEventListener('keyup', () => {
-    const passwordValue = passwordInputElem.value;
-    const invalidElem = document.querySelector('.invalidError.password');
-    const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[A-Za-z\d]{8,}$/;
+passwordInputElem.addEventListener("keyup", () => {
+  const passwordValue = passwordInputElem.value;
+  const invalidElem = document.querySelector(".invalidError.password");
+  const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[A-Za-z\d]{8,}$/;
 
-    if (!passwordRegex.test(passwordValue)) {
-        invalidElem.style.display = 'block';
-        validState.password = false;
-    } else {
-        invalidElem.style.display = 'none';
-        validState.password = true;
-    }
+  if (!passwordRegex.test(passwordValue)) {
+    invalidElem.style.display = "block";
+    validState.password = false;
+  } else {
+    invalidElem.style.display = "none";
+    validState.password = true;
+    inputValueState.password = passwordValue;
+  }
 
-    toggleSubmit();
+  toggleSubmit();
 });
 
 const toggleSubmit = () => {
-    const submitBtn = document.getElementById('js-submitBtn');
-    const allValid = Object.values(validState).every(
-        (validValue) => validValue === true
-    );
+  const allValid = Object.values(validState).every(
+    (validValue) => validValue === true
+  );
 
-    submitBtn.disabled = !allValid;
+  registerSubmitBtn.disabled = !allValid;
 };
+


### PR DESCRIPTION
## 概要
[会員登録画面](https://github.com/yasu-pro/Independent_study_js_handson/issues/30#:~:text=%E3%82%84%E3%82%8B%E3%81%93%E3%81%A8%E3%83%AA%E3%82%B9%E3%83%88-,%E4%BC%9A%E5%93%A1%E7%99%BB%E9%8C%B2%E7%94%BB%E9%9D%A2,-%E4%BC%9A%E5%93%A1%E7%99%BB%E9%8C%B2%E3%81%97%E3%81%9F%E3%82%89)

## 実装内容
・入力項目からローカルストレージ(仮定のサーバー)にuser情報を登録
・すでに登録されている場合、エラーを返す(すでに登録されているメールアドレスです。)
・登録成功時に会員登録完了ページに遷移

## 悩んだポイント
・ローカルストレージに登録時stringのみなので、オブジェクト登録ができない点
  ・結果として別々で登録したが、オブジェクトをstringにして呼び出した時にオブジェクトに直してもいいかも
・仮サーバーから返される値をbooleanにしたが、条件分岐でどう早く処理を終わらせるか考えた

## その他
・フォーマット調整含む