### PR TITLE
パスワード忘れたページでアドレスが登録されていなければエラーを出す処理を追加

### DIFF
--- a/work28/src/forgot-password/js/index.js
+++ b/work28/src/forgot-password/js/index.js
@@ -36,8 +36,25 @@ const toggleSubmit = () => {
   registerSubmitBtn.disabled = !allValid;
 };
 
-registerSubmitBtn.addEventListener("click", () => {
-  const forgotPasswordForUrl = handleForgotPassword();
+const isCheckedRegisterMail = () => {
+  const registerUserInfoServer = localStorage.getItem("registerUser");
 
-  window.location.href = forgotPasswordForUrl;
+  const registerUserJson = JSON.parse(registerUserInfoServer);
+
+  if (registerUserJson.mail === inputValueState.mail) {
+    return true;
+  }
+
+  return false;
+};
+
+registerSubmitBtn.addEventListener("click", () => {
+  if (isCheckedRegisterMail()) {
+    const forgotPasswordForUrl = handleForgotPassword();
+
+    window.location.href = forgotPasswordForUrl;
+    return;
+  }
+
+  return alert("一致するアカウントが見つかりませんでした");
 });

--- a/work28/src/forgot-password/js/index.js
+++ b/work28/src/forgot-password/js/index.js
@@ -36,25 +36,25 @@ const toggleSubmit = () => {
   registerSubmitBtn.disabled = !allValid;
 };
 
-const isCheckedRegisterMail = () => {
+const isRegisteredEmail = () => {
   const registerUserInfoServer = localStorage.getItem("registerUser");
+
+  if (!registerUserInfoServer) return false;
 
   const registerUserJson = JSON.parse(registerUserInfoServer);
 
-  if (registerUserJson.mail === inputValueState.mail) {
-    return true;
-  }
+  if (registerUserJson.mail === inputValueState.mail) return true;
 
   return false;
 };
 
 registerSubmitBtn.addEventListener("click", () => {
-  if (isCheckedRegisterMail()) {
+  if (isRegisteredEmail()) {
     const forgotPasswordForUrl = handleForgotPassword();
 
     window.location.href = forgotPasswordForUrl;
     return;
   }
 
-  return alert("一致するアカウントが見つかりませんでした");
+  alert("一致するアカウントが見つかりませんでした");
 });


### PR DESCRIPTION

## 概要
・パスワード忘れたページでアドレスが登録されていなければエラーを出す処理を追加

## 実装内容
・仮サーバー(ローカルストレージ)にアドレスが登録されているか確認する関数を追加
・なければアラートを出す

## 悩んだポイント
・関数名と変数名
・処理を早く終了できるところはreturnする

## その他
なし

